### PR TITLE
Migrate to Ktor 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.aymanizz:ktor-i18n:1.0.0'
+    implementation 'com.github.aymanizz:ktor-i18n:2.0.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.aymanizz:ktor-i18n:2.0.0'
+    implementation 'com.github.aymanizz:ktor-i18n:VERSION'
 }
 ```
+where "VERSION" is dependent on the ktor version you are using.
+If you are using ktor 2.0.0 or newer, use version 2.0.0.
+If you are using older ktor versions, use version 1.0.0.
 
 #### Usage Example
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,27 +1,22 @@
-import org.gradle.jvm.tasks.Jar
-import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.3.70"
+    kotlin("jvm") version "1.6.20"
     `maven-publish`
-    id("org.jetbrains.dokka") version "0.10.1"
-    id("com.diffplug.gradle.spotless") version "4.4.0"
+    id("com.diffplug.spotless") version "6.4.2"
 }
 
 group = "com.github.aymanizz"
-version = "1.0.0"
+version = "2.0.0"
 
 repositories {
     mavenCentral()
-    maven("https://dl.bintray.com/kotlin/ktor")
-    maven("https://dl.bintray.com/kotlin/dokka")
 }
 
 dependencies {
     implementation(kotlin("stdlib"))
-    implementation("io.ktor:ktor-server-core:1.3.1")
-    testImplementation("io.ktor:ktor-server-test-host:1.3.1")
+    implementation("io.ktor:ktor-server-core:2.0.0")
+    testImplementation("io.ktor:ktor-server-test-host:2.0.0")
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
 }
 
@@ -32,18 +27,6 @@ tasks.withType<KotlinCompile>().configureEach {
 
 tasks.test {
     useJUnitPlatform()
-}
-
-tasks.getting(DokkaTask::class) {
-    outputFormat = "html"
-    outputDirectory = "$buildDir/javadoc"
-}
-
-val dokkaJar by tasks.creating(Jar::class) {
-    group = JavaBasePlugin.DOCUMENTATION_GROUP
-    description = "Assembles Kotlin docs with Dokka"
-    archiveClassifier.set("javadoc")
-    from(tasks.dokka)
 }
 
 java.withSourcesJar()
@@ -78,7 +61,6 @@ publishing {
     publications {
         create<MavenPublication>("ktor-i18n") {
             from(components["java"])
-            artifact(dokkaJar)
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation("io.ktor:ktor-server-core:2.0.0")
     testImplementation("io.ktor:ktor-server-test-host:2.0.0")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation("io.ktor:ktor-server-core:2.0.0")
     testImplementation("io.ktor:ktor-server-test-host:2.0.0")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:1.6.20")
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/github/aymanizz/ktori18n/I18n.kt
+++ b/src/main/kotlin/com/github/aymanizz/ktori18n/I18n.kt
@@ -142,7 +142,7 @@ private val CallLocaleKey = AttributeKey<Locale>("CallLocale")
  * The locale for the current call, based on accept language header, then from the optional language cookie and finally from
  * the language prefix of the request path.
  *
- * If there is no supported locale that matches the request accept language locales, the the default locale is returned.
+ * If there is no supported locale that matches the request accept language locales, the default locale is returned.
  */
 val ApplicationCall.locale
     get() = attributes.computeIfAbsent(CallLocaleKey) locale@{

--- a/src/main/kotlin/com/github/aymanizz/ktori18n/I18n.kt
+++ b/src/main/kotlin/com/github/aymanizz/ktori18n/I18n.kt
@@ -88,7 +88,7 @@ class I18n private constructor(configuration: Configuration) : MessageResolver b
 
         /**
          * Exclude calls matching the [predicate] from being redirected with language prefix by this feature.
-         * @see io.ktor.features.HttpsRedirect for example of exclusions
+         * @see io.ktor.server.plugins.httpsredirect for example of exclusions
          */
         fun exclude(predicate: (call: ApplicationCall) -> Boolean) {
             excludePredicates.add(predicate)

--- a/src/main/kotlin/com/github/aymanizz/ktori18n/I18n.kt
+++ b/src/main/kotlin/com/github/aymanizz/ktori18n/I18n.kt
@@ -122,13 +122,13 @@ class I18n private constructor(configuration: Configuration) : MessageResolver b
                 }
             }
 
-            val feature = I18n(configuration)
+            val plugin = I18n(configuration)
 
             if (configuration.useOfRedirection) {
-                pipeline.intercept(Plugins) { feature.intercept(this) }
+                pipeline.intercept(Plugins) { plugin.intercept(this) }
             }
 
-            return feature
+            return plugin
         }
     }
 }

--- a/src/main/kotlin/com/github/aymanizz/ktori18n/I18n.kt
+++ b/src/main/kotlin/com/github/aymanizz/ktori18n/I18n.kt
@@ -1,15 +1,16 @@
 package com.github.aymanizz.ktori18n
 
 import com.github.aymanizz.ktori18n.I18n.Configuration
-import io.ktor.application.Application
-import io.ktor.application.ApplicationCall
-import io.ktor.application.ApplicationCallPipeline
-import io.ktor.application.ApplicationFeature
-import io.ktor.application.feature
-import io.ktor.features.origin
 import io.ktor.http.Cookie
-import io.ktor.request.acceptLanguage
-import io.ktor.response.respondRedirect
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.ApplicationCallPipeline
+import io.ktor.server.application.ApplicationCallPipeline.ApplicationPhase.Plugins
+import io.ktor.server.application.BaseApplicationPlugin
+import io.ktor.server.application.plugin
+import io.ktor.server.plugins.origin
+import io.ktor.server.request.acceptLanguage
+import io.ktor.server.response.respondRedirect
 import io.ktor.util.AttributeKey
 import io.ktor.util.pipeline.PipelineContext
 import java.util.Locale
@@ -109,7 +110,7 @@ class I18n private constructor(configuration: Configuration) : MessageResolver b
         }
     }
 
-    companion object Feature : ApplicationFeature<ApplicationCallPipeline, Configuration, I18n> {
+    companion object Plugin : BaseApplicationPlugin<ApplicationCallPipeline, Configuration, I18n> {
 
         override val key = AttributeKey<I18n>("I18n")
 
@@ -124,7 +125,7 @@ class I18n private constructor(configuration: Configuration) : MessageResolver b
             val feature = I18n(configuration)
 
             if (configuration.useOfRedirection) {
-                pipeline.intercept(ApplicationCallPipeline.Features) { feature.intercept(this) }
+                pipeline.intercept(Plugins) { feature.intercept(this) }
             }
 
             return feature
@@ -133,7 +134,7 @@ class I18n private constructor(configuration: Configuration) : MessageResolver b
 }
 
 val Application.i18n
-    get() = feature(I18n)
+    get() = this.plugin(I18n)
 
 private val CallLocaleKey = AttributeKey<Locale>("CallLocale")
 

--- a/src/test/kotlin/com/github/aymanizz/ktori18n/I18nTests.kt
+++ b/src/test/kotlin/com/github/aymanizz/ktori18n/I18nTests.kt
@@ -1,30 +1,38 @@
 package com.github.aymanizz.ktori18n
 
 import io.ktor.server.testing.testApplication
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.util.Locale
+import kotlin.test.assertEquals
 
 internal class I18nTests {
     @Test
-    fun `throws when supported locales is not initialized`(): Unit = testApplication {
-        assertThrows<UninitializedPropertyAccessException> { install(I18n) }
-    }
-
-    @Test
-    fun `throws when supported locales is empty`(): Unit = testApplication {
-        assertThrows<IllegalArgumentException> {
-            install(I18n) { supportedLocales = listOf() }
+    fun `throws when supported locales is not initialized`() {
+        assertThrows<UninitializedPropertyAccessException> {
+            testApplication {
+                install(I18n)
+            }
         }
     }
 
     @Test
-    fun `throws when default locale not in supported locales`(): Unit = testApplication {
+    fun `throws when supported locales is empty`() {
         assertThrows<IllegalArgumentException> {
-            install(I18n) {
-                supportedLocales = listOf("en", "de").map { Locale.forLanguageTag(it) }
-                defaultLocale = Locale.forLanguageTag("ar")
+            testApplication {
+                install(I18n) { supportedLocales = listOf() }
+            }
+        }
+    }
+
+    @Test
+    fun `throws when default locale not in supported locales`() {
+        assertThrows<IllegalArgumentException> {
+            testApplication {
+                install(I18n) {
+                    supportedLocales = listOf("en", "de").map { Locale.forLanguageTag(it) }
+                    defaultLocale = Locale.forLanguageTag("ar")
+                }
             }
         }
     }
@@ -36,7 +44,7 @@ internal class I18nTests {
             supportedLocales = locales
         }
         this.application {
-            Assertions.assertEquals(locales[0], i18n.defaultLocale)
+            assertEquals(locales[0], i18n.defaultLocale)
         }
     }
 }

--- a/src/test/kotlin/com/github/aymanizz/ktori18n/I18nTests.kt
+++ b/src/test/kotlin/com/github/aymanizz/ktori18n/I18nTests.kt
@@ -1,29 +1,28 @@
 package com.github.aymanizz.ktori18n
 
-import io.ktor.application.install
-import io.ktor.server.testing.withTestApplication
+import io.ktor.server.testing.testApplication
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.util.Locale
-import kotlin.test.assertEquals
 
 internal class I18nTests {
     @Test
-    fun `throws when supported locales is not initialized`(): Unit = withTestApplication {
-        assertThrows<UninitializedPropertyAccessException> { application.install(I18n) }
+    fun `throws when supported locales is not initialized`(): Unit = testApplication {
+        assertThrows<UninitializedPropertyAccessException> { install(I18n) }
     }
 
     @Test
-    fun `throws when supported locales is empty`(): Unit = withTestApplication {
+    fun `throws when supported locales is empty`(): Unit = testApplication {
         assertThrows<IllegalArgumentException> {
-            application.install(I18n) { supportedLocales = listOf() }
+            install(I18n) { supportedLocales = listOf() }
         }
     }
 
     @Test
-    fun `throws when default locale not in supported locales`(): Unit = withTestApplication {
+    fun `throws when default locale not in supported locales`(): Unit = testApplication {
         assertThrows<IllegalArgumentException> {
-            application.install(I18n) {
+            install(I18n) {
                 supportedLocales = listOf("en", "de").map { Locale.forLanguageTag(it) }
                 defaultLocale = Locale.forLanguageTag("ar")
             }
@@ -31,11 +30,13 @@ internal class I18nTests {
     }
 
     @Test
-    fun `default locale defaults to the first supported locale`(): Unit = withTestApplication {
+    fun `default locale defaults to the first supported locale`(): Unit = testApplication {
         val locales = listOf("en", "ar").map { Locale.forLanguageTag(it) }
-        application.install(I18n) {
+        install(I18n) {
             supportedLocales = locales
         }
-        assertEquals(locales[0], application.i18n.defaultLocale)
+        this.application {
+            Assertions.assertEquals(locales[0], i18n.defaultLocale)
+        }
     }
 }


### PR DESCRIPTION
This version is fully working with ktor 2.0.0
I updated most dependencies and got rid of dokka becuase i couldn't force it to compile on my machine, both on old version and after changing to newest. (After thinking about it for a while, it won't make a difference because this library is simple enough in use and has good enough readme to not need extended documentation available outside of its source code)

I locally tested it and it works correctly, as intended on ktor 2.0.0 with ktor-html-builder:2.0.0-eap-278 and kotlinx-html-jvm:0.7.5